### PR TITLE
Fix two pre-existing test bugs surfaced when running against real Pos…

### DIFF
--- a/backend/core/tests/test_database.py
+++ b/backend/core/tests/test_database.py
@@ -119,7 +119,7 @@ async def test_answers_dal(db_session):
     await question_dal.add_question(q1)
 
     answers_dal = AnswersDAL(db_session)
-    ans1 = Answers(student_id=student.id, question_id=q1.id, answer="4")
+    ans1 = Answers(exam_id=exam.id, student_id=student.id, question_id=q1.id, answer="4")
 
     await answers_dal.add_answers([ans1])
 

--- a/backend/core/tests/test_grading_agent.py
+++ b/backend/core/tests/test_grading_agent.py
@@ -9,7 +9,7 @@ from Agents.prompts import GRADING_AGENT_PROMPT
 
 @pytest.fixture
 def mock_groq():
-    with patch("Agents.grading_agent.Groq") as mock:
+    with patch("Agents.grading_agent.AsyncGroq") as mock:
         yield mock
 
 @pytest.mark.asyncio
@@ -22,7 +22,7 @@ async def test_grading_agent_success(mock_groq):
     expected_output = {"question_id": 1, "marks": 4}
     mock_message.content = json.dumps(expected_output)
     mock_response.choices = [MagicMock(message=mock_message)]
-    mock_client.chat.completions.create.return_value = mock_response
+    mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
     mock_groq.return_value = mock_client
 
     # Execute
@@ -52,7 +52,7 @@ async def test_grading_agent_invalid_json(mock_groq):
 
     mock_message.content = "{ invalid json"
     mock_response.choices = [MagicMock(message=mock_message)]
-    mock_client.chat.completions.create.return_value = mock_response
+    mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
     mock_groq.return_value = mock_client
 
     exam_id = uuid.uuid4()
@@ -70,7 +70,7 @@ async def test_grading_agent_validation_error(mock_groq):
     # Missing required 'marks' field
     mock_message.content = json.dumps({"question_id": 1})
     mock_response.choices = [MagicMock(message=mock_message)]
-    mock_client.chat.completions.create.return_value = mock_response
+    mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
     mock_groq.return_value = mock_client
 
     exam_id = uuid.uuid4()

--- a/backend/core/tests/test_grading_task.py
+++ b/backend/core/tests/test_grading_task.py
@@ -32,7 +32,7 @@ async def test_grade_student_returns_true_when_marks_persisted(db_session):
     student = await student_dal.create_student(exam_id=exam.id, marks=None)
 
     answers_dal = AnswersDAL(db_session)
-    answer = Answers(student_id=student.id, question_id=question.id, answer="4")
+    answer = Answers(exam_id=exam.id, student_id=student.id, question_id=question.id, answer="4")
     await answers_dal.add_answers([answer])
 
     agent = AsyncMock()


### PR DESCRIPTION
…tgres

test_grading_agent.py's mock_groq fixture patched Agents.grading_agent.Groq, which doesn't exist in that module (it uses AsyncGroq) -- patch() failed with AttributeError before any test body ran. Also needed the mocked create() call to actually be awaitable (AsyncMock), since a plain MagicMock return value can't be awaited.

test_database.py::test_answers_dal and test_grading_task.py's test_grade_student_returns_true_when_marks_persisted both constructed Answers(...) without exam_id, a NOT NULL column -- fails with IntegrityError against real Postgres (sqlite's looser typing had been masking it).


Claude-Session: https://claude.ai/code/session_01HNkqniUdEkGtiB3HbKYs38